### PR TITLE
Parallelization of phenotype processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ perl calculate_score.pl <phenolyzer_gene_list> <wannovar_genome_summary.txt>
 perl disease_annotation.pl "alzheimer;brain" -p -ph -logistic -out out/sd
 ```
 
+- Parallelize phenotype processing to speed up calculations (fork subprocesses)
+```
+perl disease_annotation.pl "alzheimer;brain" -p -ph -logistic -nproc 2
+```
+
 ## License Agreement
 By using the software, you acknowledge that you agree to the terms below:
 

--- a/disease_annotation.pl
+++ b/disease_annotation.pl
@@ -168,10 +168,10 @@ $GENE_WEIGHT{"ORPHANET"}     = 1.0  unless (defined $GENE_WEIGHT{"ORPHANET"} );
 $GENE_WEIGHT{"HPO_PHENOTYPE_GENE"}     = 1.0  unless (defined $GENE_WEIGHT{"HPO_PHENOTYPE_GENE"} );
 $addon_gene_disease_weight   = 1.0  unless (defined $addon_gene_disease_weight);
 $addon_gene_gene_weight      = 1.0  unless (defined $addon_gene_gene_weight);
-$user_nproc                  = 0    unless (defined $user_nproc);
+$user_nproc                  = 1    unless (defined $user_nproc);
 
 # Test input values
-$user_nproc >= 0 or pod2usage ("       ERROR: number of requested processes is negative");
+$user_nproc >= 1 or pod2usage ("       ERROR: number of requested processes is zero or negative");
 
 ##
 ######################################################################
@@ -338,19 +338,7 @@ sub process_terms
 	my @disease_input = @_;
 # Process each individual term first
 # Determine number of parallel subprocesses
-  my $child_procs = $user_nproc;
-	my $n_procs = $child_procs;
-# 0 and 1 correspond to forking 0 subprocesses.
-  if ($child_procs <= 1) {
-		$child_procs = 0;
-		$n_procs = 1;
-	}
-# Otherwise, set the number to number of inputs, at most
-	elsif ($child_procs > @disease_input) {
-		$child_procs = @disease_input;
-		$n_procs = $child_procs;
-	}
-
+	my $n_procs = $user_nproc <= @disease_input ? $user_nproc : @disease_input;
 	print STDERR "NOTICE: Processing $n_procs phenotypes at a time!\n";
 	if ($n_procs > 1) {
 # Run in parallel after loading ForkManager. Test if the module is available.
@@ -358,7 +346,7 @@ sub process_terms
 		if ($@) {
 			pod2usage ("Error in argument: you need to install Parallel::ForkManager module before parallelizing with the -nproc argument");
 		}
-		my $parallel_mngr = Parallel::ForkManager->new($child_procs);
+		my $parallel_mngr = Parallel::ForkManager->new($n_procs);
 	  for my $individual_term(@disease_input) 
 		{
 			$parallel_mngr->start and next;
@@ -1797,7 +1785,7 @@ sub printHeader{
         --omim_weight                   the weight for gene disease pairs in OMIM
         --orphanet_weight               the weight for gene disease pairs in Orphanet    
         --nproc                         number of parallel processes (forks) requested by the user. The code uses as much parallelism as 
-                                        allowed by the data. Setting this to 0 or 1 means no child processes are created.           
+                                        allowed by the data. Setting this to 1 means no child processes are created.           
   
 Function:       
           automatically expand the input disease term to a list of professional disease names, 

--- a/disease_annotation.pl
+++ b/disease_annotation.pl
@@ -730,7 +730,7 @@ sub phenotype_extension{
 		my $line = `perl $work_path/ontology_search.pl -o $path/hpo.obo -format id -p '$input_term' `;
 		print STDERR "NOTICE: executing ontology_search.pl to expand phenotype terms\n";
 		@hpo_ids = split("\n", $line);
-		print STDERR "NTOICE: Found ", scalar (@hpo_ids), " additional phenotype terms\n";
+		print STDERR "NOTICE: Found ", scalar (@hpo_ids), " additional phenotype terms\n";
 		
 		my @hpo_annotation = <HPO_ANNOTATION>;
 		shift @hpo_annotation;

--- a/disease_annotation.pl
+++ b/disease_annotation.pl
@@ -1773,8 +1773,8 @@ sub printHeader{
         --clinvar_weight                the weight for gene disease pairs in Clinvar
         --omim_weight                   the weight for gene disease pairs in OMIM
         --orphanet_weight               the weight for gene disease pairs in Orphanet    
-        --nproc                         max number of parallel processes requested by the user. The code uses as much parallelism as allowed by the data.
-				                                Processes are used, not threads             
+        --nproc                         number of parallel processes (forks) requested by the user. The code uses as much parallelism as 
+                                        allowed by the data. Setting this to 0 or 1 means no child processes are created.           
   
 Function:       
           automatically expand the input disease term to a list of professional disease names, 


### PR DESCRIPTION
Hi,

I've used `ForkManager` to parallelize the processing step of the phenotypes. The default behavior of the code is maintained. I decided to use forks over threads because the latter are discouraged by Perl: *The use of interpreter-based threads in Perl is officially discouraged.*

### Interface command
There is an additional parameter *-nproc* exposed to the user to set the total number of processes to use. If this parameter is <= 1, then the code proceeds as with no parallelization.

### Additional changes
In order to facilitate the interpretation of the information fed to the user via STDERR, I labelled these print statements with the corresponding disease being processed. Any tool that depends on reading this information may stop working. However, this was the only simple way to still be able to relate each line to the appropriate disease.

I hope this helps!
### Testing?
I must admit that I don't know how comprehensive my testing is, at the end of the day I only spent a couple of days with the code. So, please, feel free to criticize and comment.

### Sample result
In my computer the following commands take 13 and 24 seconds.
```
perl disease_annotation.pl "Febrile seizures;Status epilepticus" -p -ph -logistic -nproc 2
perl disease_annotation.pl "Febrile seizures;Status epilepticus" -p -ph -logistic
```
